### PR TITLE
Add "Pick a HomeCoordinator" alert instead of rotating between them

### DIFF
--- a/XCoordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XCoordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/quickbirdstudios/XCoordinator.git",
         "state": {
           "branch": null,
-          "revision": "cbbde30403422c9209e6f582315f6231da3621c9",
-          "version": "2.0.2"
+          "revision": "0c16cc7061f93d278279137277efb13385e960a6",
+          "version": "2.0.5"
         }
       }
     ]

--- a/XCoordinator-Example/Coordinators/AppCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/AppCoordinator.swift
@@ -6,20 +6,16 @@
 //  Copyright © 2018 QuickBird Studios. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import XCoordinator
 
 enum AppRoute: Route {
     case login
-    case home
+    case home(StrongRouter<HomeRoute>?)
     case newsDetail(News)
 }
 
 class AppCoordinator: NavigationCoordinator<AppRoute> {
-
-    // MARK: Stored properties
-
-    private var homeRouteTriggerCount = 0
 
     // MARK: Initialization
 
@@ -36,20 +32,37 @@ class AppCoordinator: NavigationCoordinator<AppRoute> {
             let viewModel = LoginViewModelImpl(router: unownedRouter)
             viewController.bind(to: viewModel)
             return .push(viewController)
-        case .home:
-            let presentables: [() -> Presentable] = [
-                { HomeTabCoordinator() },
-                { HomeSplitCoordinator() },
-                { HomePageCoordinator() }
-            ]
-            let presentable = presentables[homeRouteTriggerCount % presentables.count]()
-            homeRouteTriggerCount = (homeRouteTriggerCount + 1) % presentables.count
-            return .presentFullScreen(presentable, animation: .fade)
+        case let .home(router):
+            if let router = router {
+                return .presentFullScreen(router, animation: .fade)
+            }
+            let alert = UIAlertController(
+                title: "How would you like to login?",
+                message: "Please choose the type of coordinator used for the `Home` scene.",
+                preferredStyle: .alert)
+            alert.addAction(
+                .init(title: "\(HomeTabCoordinator.self)", style: .default) { [unowned self] _ in
+                    self.trigger(.home(HomeTabCoordinator().strongRouter))
+                }
+            )
+            alert.addAction(
+                .init(title: "\(HomeSplitCoordinator.self)", style: .default) { [unowned self] _ in
+                    self.trigger(.home(HomeSplitCoordinator().strongRouter))
+                }
+            )
+            alert.addAction(
+                .init(title: "\(HomePageCoordinator.self)", style: .default) { [unowned self] _ in
+                    self.trigger(.home(HomePageCoordinator().strongRouter))
+                }
+            )
+            return .present(alert)
         case .newsDetail(let news):
             return .multiple(
                 .dismissAll(),
                 .popToRoot(),
-                deepLink(AppRoute.home, HomeRoute.news, NewsRoute.newsDetail(news))
+                deepLink(AppRoute.home(HomePageCoordinator().strongRouter),
+                         HomeRoute.news,
+                         NewsRoute.newsDetail(news))
             )
         }
     }

--- a/XCoordinator-Example/Coordinators/AppCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/AppCoordinator.swift
@@ -55,6 +55,17 @@ class AppCoordinator: NavigationCoordinator<AppRoute> {
                     self.trigger(.home(HomePageCoordinator().strongRouter))
                 }
             )
+            alert.addAction(
+                .init(title: "Random", style: .default) { [unowned self] _ in
+                    let routers: [() -> StrongRouter<HomeRoute>] = [
+                        { HomeTabCoordinator().strongRouter },
+                        { HomeSplitCoordinator().strongRouter },
+                        { HomeTabCoordinator().strongRouter }
+                    ]
+                    let router = routers.randomElement().map { $0() }
+                    self.trigger(.home(router))
+                }
+            )
             return .present(alert)
         case .newsDetail(let news):
             return .multiple(

--- a/XCoordinator-Example/Coordinators/HomePageCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/HomePageCoordinator.swift
@@ -23,8 +23,10 @@ class HomePageCoordinator: PageCoordinator<HomeRoute> {
         self.userListRouter = userListRouter
         
         super.init(
-            rootViewController: .init(),
-            pages: [newsRouter, userListRouter], loop: true,
+            rootViewController: .init(transitionStyle: .scroll,
+                                      navigationOrientation: .horizontal,
+                                      options: nil),
+            pages: [userListRouter, newsRouter], loop: false,
             set: userListRouter, direction: .forward
         )
     }

--- a/XCoordinator-Example/Scenes/Login/LoginViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/Login/LoginViewModelImpl.swift
@@ -19,7 +19,7 @@ class LoginViewModelImpl: LoginViewModel, LoginViewModelInput, LoginViewModelOut
     // MARK: Actions
 
     private lazy var loginAction = CocoaAction { [unowned self] in
-        self.router.rx.trigger(.home)
+        self.router.rx.trigger(.home(nil))
     }
 
     // MARK: Stored properties


### PR DESCRIPTION
This (hopefully) makes it easier for users to see that there are different HomeCoordinators at play and allows us to test them easier.

It further addresses the UX problem mentioned in https://github.com/quickbirdstudios/XCoordinator-Example/issues/2.