### PR TITLE
3.0.0

### DIFF
--- a/XCoordinator-Example.xcodeproj/project.pbxproj
+++ b/XCoordinator-Example.xcodeproj/project.pbxproj
@@ -57,7 +57,6 @@
 		9B5657D42315FB3500F4F4F7 /* TransitionAnimation+Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5657A42315FB3500F4F4F7 /* TransitionAnimation+Defaults.swift */; };
 		9B5657D62315FB3500F4F4F7 /* CGAffineTransform+InPlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5657A62315FB3500F4F4F7 /* CGAffineTransform+InPlace.swift */; };
 		9B5657D92315FB9700F4F4F7 /* Action in Frameworks */ = {isa = PBXBuildFile; productRef = 9B5657D82315FB9700F4F4F7 /* Action */; };
-		9B5657DC2315FC1000F4F4F7 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 9B5657DB2315FC1000F4F4F7 /* RxCocoa */; };
 		9BD3EBF42330CE46005861BF /* Transitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD3EBF32330CE46005861BF /* Transitions.swift */; };
 		9BD3EBFD2330D84F005861BF /* XCText+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD3EBF62330D84E005861BF /* XCText+Extras.swift */; };
 		9BD3EBFE2330D84F005861BF /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD3EBF72330D84F005861BF /* XCTestManifests.swift */; };
@@ -167,7 +166,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9B0A753A2316C1810092CA3A /* XCoordinatorRx in Frameworks */,
-				9B5657DC2315FC1000F4F4F7 /* RxCocoa in Frameworks */,
 				9B5657D92315FB9700F4F4F7 /* Action in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -449,7 +447,6 @@
 			name = "XCoordinator-Example";
 			packageProductDependencies = (
 				9B5657D82315FB9700F4F4F7 /* Action */,
-				9B5657DB2315FC1000F4F4F7 /* RxCocoa */,
 				9B0A75392316C1810092CA3A /* XCoordinatorRx */,
 			);
 			productName = "XCoordinator-Example";
@@ -526,7 +523,6 @@
 			mainGroup = 9B56572C2315FA7B00F4F4F7;
 			packageReferences = (
 				9B5657D72315FB9700F4F4F7 /* XCRemoteSwiftPackageReference "Action" */,
-				9B5657DA2315FC1000F4F4F7 /* XCRemoteSwiftPackageReference "RxSwift" */,
 				9B5657DD2315FC5C00F4F4F7 /* XCRemoteSwiftPackageReference "XCoordinator" */,
 			);
 			productRefGroup = 9B5657362315FA7B00F4F4F7 /* Products */;
@@ -956,20 +952,12 @@
 				minimumVersion = 4.0.1;
 			};
 		};
-		9B5657DA2315FC1000F4F4F7 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ReactiveX/RxSwift.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.0.1;
-			};
-		};
 		9B5657DD2315FC5C00F4F4F7 /* XCRemoteSwiftPackageReference "XCoordinator" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/quickbirdstudios/XCoordinator.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.2;
+				branch = feature/3.0.0;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -984,11 +972,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9B5657D72315FB9700F4F4F7 /* XCRemoteSwiftPackageReference "Action" */;
 			productName = Action;
-		};
-		9B5657DB2315FC1000F4F4F7 /* RxCocoa */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9B5657DA2315FC1000F4F4F7 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = RxCocoa;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/XCoordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XCoordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/quickbirdstudios/XCoordinator.git",
       "state" : {
         "branch" : "feature/3.0.0",
-        "revision" : "2f68db87dffcc69d4ad3bdca5d0ca7c1f21ca78f"
+        "revision" : "aef3a89868b4e12e6191f2d72282cb9415dbc6ea"
       }
     }
   ],

--- a/XCoordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XCoordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,34 +1,32 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Action",
-        "repositoryURL": "https://github.com/RxSwiftCommunity/Action.git",
-        "state": {
-          "branch": null,
-          "revision": "cdade63f7bbe1f5e1eff7779e5858a796dc2c001",
-          "version": "4.0.1"
-        }
-      },
-      {
-        "package": "RxSwift",
-        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "b3e888b4972d9bc76495dd74d30a8c7fad4b9395",
-          "version": "5.0.1"
-        }
-      },
-      {
-        "package": "XCoordinator",
-        "repositoryURL": "https://github.com/quickbirdstudios/XCoordinator.git",
-        "state": {
-          "branch": null,
-          "revision": "0c16cc7061f93d278279137277efb13385e960a6",
-          "version": "2.0.5"
-        }
+  "pins" : [
+    {
+      "identity" : "action",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/Action.git",
+      "state" : {
+        "revision" : "21110e93ef7b08ce9f01806827e4f381b5b09ab1",
+        "version" : "4.3.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "b4307ba0b6425c0ba4178e138799946c3da594f8",
+        "version" : "6.5.0"
+      }
+    },
+    {
+      "identity" : "xcoordinator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/quickbirdstudios/XCoordinator.git",
+      "state" : {
+        "branch" : "feature/3.0.0",
+        "revision" : "e5ab085bbd758cb6edaa265b62bd2a8ea318c093"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/XCoordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XCoordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/quickbirdstudios/XCoordinator.git",
       "state" : {
         "branch" : "feature/3.0.0",
-        "revision" : "e5ab085bbd758cb6edaa265b62bd2a8ea318c093"
+        "revision" : "3e1d1ab83a08ec0416f8715e3f1eae8ed233bad1"
       }
     }
   ],

--- a/XCoordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XCoordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/quickbirdstudios/XCoordinator.git",
       "state" : {
         "branch" : "feature/3.0.0",
-        "revision" : "3e1d1ab83a08ec0416f8715e3f1eae8ed233bad1"
+        "revision" : "2f68db87dffcc69d4ad3bdca5d0ca7c1f21ca78f"
       }
     }
   ],

--- a/XCoordinator-Example/Common/AppDelegate.swift
+++ b/XCoordinator-Example/Common/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import XCoordinator
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -14,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: Stored properties
 
     private lazy var mainWindow = UIWindow()
-    private let router = AppCoordinator().strongRouter
+    private let router: any Router<AppRoute> = AppCoordinator()
 
     // MARK: UIApplicationDelegate
 

--- a/XCoordinator-Example/Coordinators/AboutCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/AboutCoordinator.swift
@@ -29,7 +29,7 @@ class AboutCoordinator: NavigationCoordinator<AboutRoute> {
         switch route {
         case .home:
             let viewController = AboutViewController()
-            let viewModel = AboutViewModelImpl(router: unownedRouter)
+            let viewModel = AboutViewModelImpl(router: self)
             viewController.bind(to: viewModel)
             return .push(viewController)
         case .website:

--- a/XCoordinator-Example/Coordinators/AppCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/AppCoordinator.swift
@@ -11,7 +11,7 @@ import XCoordinator
 
 enum AppRoute: Route {
     case login
-    case home(StrongRouter<HomeRoute>?)
+    case home((any Presentable)?)
     case newsDetail(News)
 }
 
@@ -29,11 +29,11 @@ class AppCoordinator: NavigationCoordinator<AppRoute> {
         switch route {
         case .login:
             let viewController = LoginViewController.instantiateFromNib()
-            let viewModel = LoginViewModelImpl(router: unownedRouter)
+            let viewModel = LoginViewModelImpl(router: self)
             viewController.bind(to: viewModel)
             return .push(viewController)
         case let .home(router):
-            if let router = router {
+            if let router {
                 return .presentFullScreen(router, animation: .fade)
             }
             let alert = UIAlertController(
@@ -42,25 +42,25 @@ class AppCoordinator: NavigationCoordinator<AppRoute> {
                 preferredStyle: .alert)
             alert.addAction(
                 .init(title: "\(HomeTabCoordinator.self)", style: .default) { [unowned self] _ in
-                    self.trigger(.home(HomeTabCoordinator().strongRouter))
+                    self.trigger(.home(HomeTabCoordinator()))
                 }
             )
             alert.addAction(
                 .init(title: "\(HomeSplitCoordinator.self)", style: .default) { [unowned self] _ in
-                    self.trigger(.home(HomeSplitCoordinator().strongRouter))
+                    self.trigger(.home(HomeSplitCoordinator()))
                 }
             )
             alert.addAction(
                 .init(title: "\(HomePageCoordinator.self)", style: .default) { [unowned self] _ in
-                    self.trigger(.home(HomePageCoordinator().strongRouter))
+                    self.trigger(.home(HomePageCoordinator()))
                 }
             )
             alert.addAction(
                 .init(title: "Random", style: .default) { [unowned self] _ in
-                    let routers: [() -> StrongRouter<HomeRoute>] = [
-                        { HomeTabCoordinator().strongRouter },
-                        { HomeSplitCoordinator().strongRouter },
-                        { HomeTabCoordinator().strongRouter }
+                    let routers: [() -> any Presentable] = [
+                        { HomeTabCoordinator() },
+                        { HomeSplitCoordinator() },
+                        { HomeTabCoordinator() }
                     ]
                     let router = routers.randomElement().map { $0() }
                     self.trigger(.home(router))
@@ -71,7 +71,7 @@ class AppCoordinator: NavigationCoordinator<AppRoute> {
             return .multiple(
                 .dismissAll(),
                 .popToRoot(),
-                deepLink(AppRoute.home(HomePageCoordinator().strongRouter),
+                deepLink(AppRoute.home(HomePageCoordinator()),
                          HomeRoute.news,
                          NewsRoute.newsDetail(news))
             )

--- a/XCoordinator-Example/Coordinators/AppCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/AppCoordinator.swift
@@ -11,7 +11,7 @@ import XCoordinator
 
 enum AppRoute: Route {
     case login
-    case home((any Presentable)?)
+    case home((any Router<HomeRoute>)?)
     case newsDetail(News)
 }
 
@@ -34,7 +34,7 @@ class AppCoordinator: NavigationCoordinator<AppRoute> {
             return .push(viewController)
         case let .home(router):
             if let router {
-                return .presentFullScreen(router, animation: .fade)
+                return .presentFullScreen(router.asPresentable, animation: .fade)
             }
             let alert = UIAlertController(
                 title: "How would you like to login?",
@@ -57,12 +57,16 @@ class AppCoordinator: NavigationCoordinator<AppRoute> {
             )
             alert.addAction(
                 .init(title: "Random", style: .default) { [unowned self] _ in
-                    let routers: [() -> any Presentable] = [
-                        { HomeTabCoordinator() },
-                        { HomeSplitCoordinator() },
-                        { HomeTabCoordinator() }
-                    ]
-                    let router = routers.randomElement().map { $0() }
+                    let router: any Router<HomeRoute> = {
+                        switch Int.random(in: 0..<3) {
+                        case 0:
+                            return HomeTabCoordinator()
+                        case 1:
+                            return HomeSplitCoordinator()
+                        default:
+                            return HomeTabCoordinator()
+                        }
+                    }()
                     self.trigger(.home(router))
                 }
             )

--- a/XCoordinator-Example/Coordinators/HomePageCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/HomePageCoordinator.swift
@@ -12,13 +12,13 @@ class HomePageCoordinator: PageCoordinator<HomeRoute> {
 
     // MARK: Stored properties
 
-    private let newsRouter: StrongRouter<NewsRoute>
-    private let userListRouter: StrongRouter<UserListRoute>
+    private let newsRouter: any Presentable
+    private let userListRouter: any Presentable
 
     // MARK: Initialization
 
-    init(newsRouter: StrongRouter<NewsRoute> = NewsCoordinator().strongRouter,
-         userListRouter: StrongRouter<UserListRoute> = UserListCoordinator().strongRouter) {
+    init(newsRouter: any Presentable = NewsCoordinator(),
+         userListRouter: any Presentable = UserListCoordinator()) {
         self.newsRouter = newsRouter
         self.userListRouter = userListRouter
         

--- a/XCoordinator-Example/Coordinators/HomePageCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/HomePageCoordinator.swift
@@ -12,13 +12,13 @@ class HomePageCoordinator: PageCoordinator<HomeRoute> {
 
     // MARK: Stored properties
 
-    private let newsRouter: any Presentable
-    private let userListRouter: any Presentable
+    private let newsRouter: any Router<NewsRoute>
+    private let userListRouter: any Router<UserListRoute>
 
     // MARK: Initialization
 
-    init(newsRouter: any Presentable = NewsCoordinator(),
-         userListRouter: any Presentable = UserListCoordinator()) {
+    init(newsRouter: any Router<NewsRoute> = NewsCoordinator(),
+         userListRouter: any Router<UserListRoute> = UserListCoordinator()) {
         self.newsRouter = newsRouter
         self.userListRouter = userListRouter
         
@@ -26,8 +26,8 @@ class HomePageCoordinator: PageCoordinator<HomeRoute> {
             rootViewController: .init(transitionStyle: .scroll,
                                       navigationOrientation: .horizontal,
                                       options: nil),
-            pages: [userListRouter, newsRouter], loop: false,
-            set: userListRouter, direction: .forward
+            pages: [userListRouter.asPresentable, newsRouter.asPresentable], loop: false,
+            set: userListRouter.asPresentable, direction: .forward
         )
     }
 
@@ -36,9 +36,9 @@ class HomePageCoordinator: PageCoordinator<HomeRoute> {
     override func prepareTransition(for route: HomeRoute) -> PageTransition {
         switch route {
         case .news:
-            return .set(newsRouter, direction: .forward)
+            return .set(newsRouter.asPresentable, direction: .forward)
         case .userList:
-            return .set(userListRouter, direction: .reverse)
+            return .set(userListRouter.asPresentable, direction: .reverse)
         }
     }
 

--- a/XCoordinator-Example/Coordinators/HomeSplitCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/HomeSplitCoordinator.swift
@@ -12,17 +12,17 @@ class HomeSplitCoordinator: SplitCoordinator<HomeRoute> {
 
     // MARK: Stored properties
 
-    private let newsRouter: any Presentable
-    private let userListRouter: any Presentable
+    private let newsRouter: any Router<NewsRoute>
+    private let userListRouter: any Router<UserListRoute>
 
     // MARK: Initialization
 
-    init(newsRouter: any Presentable = NewsCoordinator(),
-         userListRouter: any Presentable = UserListCoordinator()) {
+    init(newsRouter: any Router<NewsRoute> = NewsCoordinator(),
+         userListRouter: any Router<UserListRoute> = UserListCoordinator()) {
         self.newsRouter = newsRouter
         self.userListRouter = userListRouter
 
-        super.init(primary: userListRouter, secondary: newsRouter)
+        super.init(primary: userListRouter.asPresentable, secondary: newsRouter.asPresentable)
     }
 
     // MARK: Overrides
@@ -30,10 +30,18 @@ class HomeSplitCoordinator: SplitCoordinator<HomeRoute> {
     override func prepareTransition(for route: HomeRoute) -> SplitTransition {
         switch route {
         case .news:
-            return .showDetail(newsRouter)
+            return .showDetail(newsRouter.asPresentable)
         case .userList:
-            return .show(userListRouter)
+            return .show(userListRouter.asPresentable)
         }
+    }
+
+}
+
+extension Router {
+
+    var asPresentable: any Presentable {
+        self
     }
 
 }

--- a/XCoordinator-Example/Coordinators/HomeSplitCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/HomeSplitCoordinator.swift
@@ -12,17 +12,17 @@ class HomeSplitCoordinator: SplitCoordinator<HomeRoute> {
 
     // MARK: Stored properties
 
-    private let newsRouter: StrongRouter<NewsRoute>
-    private let userListRouter: StrongRouter<UserListRoute>
+    private let newsRouter: any Presentable
+    private let userListRouter: any Presentable
 
     // MARK: Initialization
 
-    init(newsRouter: StrongRouter<NewsRoute> = NewsCoordinator().strongRouter,
-         userListRouter: StrongRouter<UserListRoute> = UserListCoordinator().strongRouter) {
+    init(newsRouter: any Presentable = NewsCoordinator(),
+         userListRouter: any Presentable = UserListCoordinator()) {
         self.newsRouter = newsRouter
         self.userListRouter = userListRouter
 
-        super.init(master: userListRouter, detail: newsRouter)
+        super.init(primary: userListRouter, secondary: newsRouter)
     }
 
     // MARK: Overrides

--- a/XCoordinator-Example/Coordinators/HomeSplitCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/HomeSplitCoordinator.swift
@@ -37,11 +37,3 @@ class HomeSplitCoordinator: SplitCoordinator<HomeRoute> {
     }
 
 }
-
-extension Router {
-
-    var asPresentable: any Presentable {
-        self
-    }
-
-}

--- a/XCoordinator-Example/Coordinators/HomeTabCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/HomeTabCoordinator.swift
@@ -18,8 +18,8 @@ class HomeTabCoordinator: TabBarCoordinator<HomeRoute> {
 
     // MARK: Stored properties
 
-    private let newsRouter: any Presentable
-    private let userListRouter: any Presentable
+    private let newsRouter: any Router<NewsRoute>
+    private let userListRouter: any Router<UserListRoute>
 
     // MARK: Initialization
 
@@ -33,11 +33,11 @@ class HomeTabCoordinator: TabBarCoordinator<HomeRoute> {
         self.init(newsRouter: newsCoordinator, userListRouter: userListCoordinator)
     }
 
-    init(newsRouter: any Presentable, userListRouter: any Presentable) {
+    init(newsRouter: any Router<NewsRoute>, userListRouter: any Router<UserListRoute>) {
         self.newsRouter = newsRouter
         self.userListRouter = userListRouter
 
-        super.init(tabs: [newsRouter, userListRouter], select: userListRouter)
+        super.init(tabs: [newsRouter.asPresentable, userListRouter.asPresentable], select: userListRouter.asPresentable)
     }
 
     // MARK: Overrides
@@ -45,9 +45,9 @@ class HomeTabCoordinator: TabBarCoordinator<HomeRoute> {
     override func prepareTransition(for route: HomeRoute) -> TabBarTransition {
         switch route {
         case .news:
-            return .select(newsRouter)
+            return .select(newsRouter.asPresentable)
         case .userList:
-            return .select(userListRouter)
+            return .select(userListRouter.asPresentable)
         }
     }
 

--- a/XCoordinator-Example/Coordinators/HomeTabCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/HomeTabCoordinator.swift
@@ -18,8 +18,8 @@ class HomeTabCoordinator: TabBarCoordinator<HomeRoute> {
 
     // MARK: Stored properties
 
-    private let newsRouter: StrongRouter<NewsRoute>
-    private let userListRouter: StrongRouter<UserListRoute>
+    private let newsRouter: any Presentable
+    private let userListRouter: any Presentable
 
     // MARK: Initialization
 
@@ -30,12 +30,10 @@ class HomeTabCoordinator: TabBarCoordinator<HomeRoute> {
         let userListCoordinator = UserListCoordinator()
         userListCoordinator.rootViewController.tabBarItem = UITabBarItem(tabBarSystemItem: .more, tag: 1)
 
-        self.init(newsRouter: newsCoordinator.strongRouter,
-                  userListRouter: userListCoordinator.strongRouter)
+        self.init(newsRouter: newsCoordinator, userListRouter: userListCoordinator)
     }
 
-    init(newsRouter: StrongRouter<NewsRoute>,
-         userListRouter: StrongRouter<UserListRoute>) {
+    init(newsRouter: any Presentable, userListRouter: any Presentable) {
         self.newsRouter = newsRouter
         self.userListRouter = userListRouter
 

--- a/XCoordinator-Example/Coordinators/NewsCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/NewsCoordinator.swift
@@ -29,7 +29,7 @@ class NewsCoordinator: NavigationCoordinator<NewsRoute> {
         case .news:
             let viewController = NewsViewController.instantiateFromNib()
             let service = MockNewsService()
-            let viewModel = NewsViewModelImpl(newsService: service, router: unownedRouter)
+            let viewModel = NewsViewModelImpl(newsService: service, router: self)
             viewController.bind(to: viewModel)
             return .push(viewController)
         case .newsDetail(let news):

--- a/XCoordinator-Example/Coordinators/UserCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/UserCoordinator.swift
@@ -34,7 +34,7 @@ class UserCoordinator: NavigationCoordinator<UserRoute> {
             return .push(viewController, animation: .fade)
         case let .user(username):
             let viewController = UserViewController.instantiateFromNib()
-            let viewModel = UserViewModelImpl(router: unownedRouter, username: username)
+            let viewModel = UserViewModelImpl(router: self, username: username)
             viewController.bind(to: viewModel)
             return .push(viewController)
         case let .alert(title, message):

--- a/XCoordinator-Example/Coordinators/UserListCoordinator.swift
+++ b/XCoordinator-Example/Coordinators/UserListCoordinator.swift
@@ -31,12 +31,12 @@ class UserListCoordinator: NavigationCoordinator<UserListRoute> {
         switch route {
         case .home:
             let viewController = HomeViewController.instantiateFromNib()
-            let viewModel = HomeViewModelImpl(router: unownedRouter)
+            let viewModel = HomeViewModelImpl(router: self)
             viewController.bind(to: viewModel)
             return .push(viewController)
         case .users:
             let viewController = UsersViewController.instantiateFromNib()
-            let viewModel = UsersViewModelImpl(userService: MockUserService(), router: unownedRouter)
+            let viewModel = UsersViewModelImpl(userService: MockUserService(), router: self)
             viewController.bind(to: viewModel)
             return .push(viewController, animation: .fade)
         case .user(let username):

--- a/XCoordinator-Example/Scenes/About/AboutViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/About/AboutViewModelImpl.swift
@@ -20,7 +20,7 @@ class AboutViewModelImpl: AboutViewModel, AboutViewModelInput, AboutViewModelOut
     // MARK: Actions
 
     private lazy var openWebsiteAction = CocoaAction { [unowned self] in
-        self.router.rxTrigger(.website)
+        self.router.rx.trigger(.website)
     }
 
     // MARK: Outputs

--- a/XCoordinator-Example/Scenes/About/AboutViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/About/AboutViewModelImpl.swift
@@ -20,7 +20,7 @@ class AboutViewModelImpl: AboutViewModel, AboutViewModelInput, AboutViewModelOut
     // MARK: Actions
 
     private lazy var openWebsiteAction = CocoaAction { [unowned self] in
-        self.router.rx.trigger(.website)
+        self.router.rxTrigger(.website)
     }
 
     // MARK: Outputs
@@ -29,11 +29,11 @@ class AboutViewModelImpl: AboutViewModel, AboutViewModelInput, AboutViewModelOut
 
     // MARK: Stored properties
 
-    private let router: UnownedRouter<AboutRoute>
+    private unowned let router: any Router<AboutRoute>
 
     // MARK: Initialization
 
-    init(router: UnownedRouter<AboutRoute>) {
+    init(router: any Router<AboutRoute>) {
         self.router = router
     }
 

--- a/XCoordinator-Example/Scenes/Home/HomeViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/Home/HomeViewModelImpl.swift
@@ -22,15 +22,15 @@ class HomeViewModelImpl: HomeViewModel, HomeViewModelInput, HomeViewModelOutput 
     // MARK: Actions
 
     private lazy var logoutAction = CocoaAction { [unowned self] in
-        self.router.rxTrigger(.logout)
+        self.router.rx.trigger(.logout)
     }
 
     private lazy var usersAction = CocoaAction { [unowned self] in
-        self.router.rxTrigger(.users)
+        self.router.rx.trigger(.users)
     }
 
     private lazy var aboutAction = CocoaAction { [unowned self] in
-        self.router.rxTrigger(.about)
+        self.router.rx.trigger(.about)
     }
     // MARK: Stored properties
 

--- a/XCoordinator-Example/Scenes/Home/HomeViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/Home/HomeViewModelImpl.swift
@@ -22,23 +22,23 @@ class HomeViewModelImpl: HomeViewModel, HomeViewModelInput, HomeViewModelOutput 
     // MARK: Actions
 
     private lazy var logoutAction = CocoaAction { [unowned self] in
-        self.router.rx.trigger(.logout)
+        self.router.rxTrigger(.logout)
     }
 
     private lazy var usersAction = CocoaAction { [unowned self] in
-        self.router.rx.trigger(.users)
+        self.router.rxTrigger(.users)
     }
 
     private lazy var aboutAction = CocoaAction { [unowned self] in
-        self.router.rx.trigger(.about)
+        self.router.rxTrigger(.about)
     }
     // MARK: Stored properties
 
-    private let router: UnownedRouter<UserListRoute>
+    private unowned let router: any Router<UserListRoute>
 
     // MARK: Initialization
 
-    init(router: UnownedRouter<UserListRoute>) {
+    init(router: any Router<UserListRoute>) {
         self.router = router
     }
 

--- a/XCoordinator-Example/Scenes/Login/LoginViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/Login/LoginViewModelImpl.swift
@@ -19,16 +19,16 @@ class LoginViewModelImpl: LoginViewModel, LoginViewModelInput, LoginViewModelOut
     // MARK: Actions
 
     private lazy var loginAction = CocoaAction { [unowned self] in
-        self.router.rx.trigger(.home(nil))
+        self.router.rxTrigger(.home(nil))
     }
 
     // MARK: Stored properties
 
-    private let router: UnownedRouter<AppRoute>
+    private unowned let router: any Router<AppRoute>
 
     // MARK: Initialization
 
-    init(router: UnownedRouter<AppRoute>) {
+    init(router: any Router<AppRoute>) {
         self.router = router
     }
 }

--- a/XCoordinator-Example/Scenes/Login/LoginViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/Login/LoginViewModelImpl.swift
@@ -19,7 +19,7 @@ class LoginViewModelImpl: LoginViewModel, LoginViewModelInput, LoginViewModelOut
     // MARK: Actions
 
     private lazy var loginAction = CocoaAction { [unowned self] in
-        self.router.rxTrigger(.home(nil))
+        self.router.rx.trigger(.home(nil))
     }
 
     // MARK: Stored properties

--- a/XCoordinator-Example/Scenes/News/NewsViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/News/NewsViewModelImpl.swift
@@ -19,7 +19,7 @@ class NewsViewModelImpl: NewsViewModel, NewsViewModelInput, NewsViewModelOutput 
     // MARK: Actions
 
     lazy var newsSelectedAction = Action<News, Void> { [unowned self] news in
-        self.router.rxTrigger(.newsDetail(news))
+        self.router.rx.trigger(.newsDetail(news))
     }
 
     // MARK: Outputs

--- a/XCoordinator-Example/Scenes/News/NewsViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/News/NewsViewModelImpl.swift
@@ -19,7 +19,7 @@ class NewsViewModelImpl: NewsViewModel, NewsViewModelInput, NewsViewModelOutput 
     // MARK: Actions
 
     lazy var newsSelectedAction = Action<News, Void> { [unowned self] news in
-        self.router.rx.trigger(.newsDetail(news))
+        self.router.rxTrigger(.newsDetail(news))
     }
 
     // MARK: Outputs
@@ -32,11 +32,11 @@ class NewsViewModelImpl: NewsViewModel, NewsViewModelInput, NewsViewModelOutput 
     // MARK: Stored properties
 
     private let newsService: NewsService
-    private let router: UnownedRouter<NewsRoute>
+    private unowned let router: any Router<NewsRoute>
 
     // MARK: Initialization
 
-    init(newsService: NewsService, router: UnownedRouter<NewsRoute>) {
+    init(newsService: NewsService, router: any Router<NewsRoute>) {
         self.newsService = newsService
         self.newsObservable = .just(newsService.mostRecentNews())
         self.router = router

--- a/XCoordinator-Example/Scenes/User/UserViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/User/UserViewModelImpl.swift
@@ -20,11 +20,11 @@ class UserViewModelImpl: UserViewModel, UserViewModelInput, UserViewModelOutput 
     // MARK: Actions
 
     private lazy var alertAction = CocoaAction { [unowned self] in
-        self.router.rx.trigger(.alert(title: "Hey", message: "You are awesome!"))
+        self.router.rxTrigger(.alert(title: "Hey", message: "You are awesome!"))
     }
 
     private lazy var closeAction = CocoaAction { [unowned self] in
-        self.router.rx.trigger(.users)
+        self.router.rxTrigger(.users)
     }
 
     // MARK: Outputs
@@ -33,11 +33,11 @@ class UserViewModelImpl: UserViewModel, UserViewModelInput, UserViewModelOutput 
 
     // MARK: Stored properties
 
-    private let router: UnownedRouter<UserRoute>
+    private unowned let router: any Router<UserRoute>
 
     // MARK: Initialization
 
-    init(router: UnownedRouter<UserRoute>, username: String) {
+    init(router: any Router<UserRoute>, username: String) {
         self.router = router
         self.username = .just(username)
     }

--- a/XCoordinator-Example/Scenes/User/UserViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/User/UserViewModelImpl.swift
@@ -20,11 +20,11 @@ class UserViewModelImpl: UserViewModel, UserViewModelInput, UserViewModelOutput 
     // MARK: Actions
 
     private lazy var alertAction = CocoaAction { [unowned self] in
-        self.router.rxTrigger(.alert(title: "Hey", message: "You are awesome!"))
+        self.router.rx.trigger(.alert(title: "Hey", message: "You are awesome!"))
     }
 
     private lazy var closeAction = CocoaAction { [unowned self] in
-        self.router.rxTrigger(.users)
+        self.router.rx.trigger(.users)
     }
 
     // MARK: Outputs

--- a/XCoordinator-Example/Scenes/UserList/UsersViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/UserList/UsersViewModelImpl.swift
@@ -19,7 +19,7 @@ class UsersViewModelImpl: UsersViewModel, UsersViewModelInput, UsersViewModelOut
     // MARK: Actions
 
     private lazy var showUserAction = Action<User, Void> { [unowned self] user in
-        self.router.rx.trigger(.user(user.name))
+        self.router.rxTrigger(.user(user.name))
     }
 
     // MARK: Outputs
@@ -29,11 +29,11 @@ class UsersViewModelImpl: UsersViewModel, UsersViewModelInput, UsersViewModelOut
     // MARK: Stored properties
 
     private let userService: UserService
-    private let router: UnownedRouter<UserListRoute>
+    private unowned let router: any Router<UserListRoute>
 
     // MARK: Initialization
 
-    init(userService: UserService, router: UnownedRouter<UserListRoute>) {
+    init(userService: UserService, router: any Router<UserListRoute>) {
         self.userService = userService
         self.router = router
     }

--- a/XCoordinator-Example/Scenes/UserList/UsersViewModelImpl.swift
+++ b/XCoordinator-Example/Scenes/UserList/UsersViewModelImpl.swift
@@ -19,7 +19,7 @@ class UsersViewModelImpl: UsersViewModel, UsersViewModelInput, UsersViewModelOut
     // MARK: Actions
 
     private lazy var showUserAction = Action<User, Void> { [unowned self] user in
-        self.router.rxTrigger(.user(user.name))
+        self.router.rx.trigger(.user(user.name))
     }
 
     // MARK: Outputs


### PR DESCRIPTION
Changelog:

- Refactor example app to get rid of WeakRouter/UnownedRouter/StrongRouter in favor of new Swift features.

Open Issues:

- At the moment, all existentials need to use `asPresentable` to make them be usable in transitions. This makes it potentially harder to use, especially for beginners.